### PR TITLE
Fix #2

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 env:
   node: true
+  browser: true
   mocha: true
 extends: 'eslint:recommended'
 rules:

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 
 Generate Password is a (relatively) extensive library for generating random and unique passwords in browsers.
 This is a fork of the original generate-password package https://github.com/brendanashworth/generate-password, but unfortunately it doesn't and [won't](https://github.com/brendanashworth/generate-password/pull/21) support browsers.
-I tested this package with Angular 4 and confirmed it's working in
+Confirmed to be working with Angular 4, 5 and 6 in these browsers:
 
 - Google Chrome 60.0.3112.113
 - Firefox 55.0.3
 - Internet Explorer 11
-
-(I will extend this list in the future)
 
 ## Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-password-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-password-browser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Easy library for generating unique passwords in browsers.",
   "main": "main.js",
   "types": "src/generate.d.ts",

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,3 +1,8 @@
+// https://github.com/angular/angular-cli/issues/9827#issuecomment-386154063
+if (typeof(window) !== 'undefined') {
+	window.global = window.global || window;
+}
+
 var randomBytes = require('randombytes');
 
 var self = module.exports;


### PR DESCRIPTION
Angular 6 removed the shim for 'global', thus breaking this package.

See https://github.com/angular/angular-cli/issues/9827#issuecomment-386154063